### PR TITLE
Fixed Settings path directory causing the slashes to be a part of filename on Linux

### DIFF
--- a/OriNoco/Settings.cs
+++ b/OriNoco/Settings.cs
@@ -7,7 +7,14 @@ namespace OriNoco
 {
     public static class Settings
     {
-        public static string SettingsPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + "\\OriNoco\\Settings.json";
+        public static string SettingsDirPath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "OriNoco"
+        );
+        public static string SettingsPath = Path.Combine(
+            SettingsDirPath,
+            "Settings.json"
+        );
         public static SettingsData Data = new SettingsData();
 
         public static void Load()
@@ -32,14 +39,13 @@ namespace OriNoco
 
         public static void Save()
         {
-            var content = JsonSerializer.Serialize(Data, new JsonSerializerOptions() { 
+            var content = JsonSerializer.Serialize(Data, new JsonSerializerOptions() {
                 WriteIndented = true
             });
             if (content != null)
             {
-                var localDirectory = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + "\\OriNoco";
-                if (!Directory.Exists(localDirectory))
-                    Directory.CreateDirectory(localDirectory);
+                if (!Directory.Exists(SettingsDirPath))
+                    Directory.CreateDirectory(SettingsDirPath);
 
                 File.WriteAllText(SettingsPath, content);
             }


### PR DESCRIPTION
Example image of how that looks like on Linux. Just fixed it by just using the `Path.Combine` which generally should use the slashes depends on the platform its running.

![image](https://github.com/user-attachments/assets/ee69eb1a-f8e0-4f97-8ef8-4d1f487ba720)
